### PR TITLE
feat: introduce window-based view management and window splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "parking_lot",
  "ropey",
  "serde",
+ "slotmap",
  "thiserror 2.0.17",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ futures-util = "0.3.31"
 hashbrown = "0.16.1"
 once_cell = "1.21.3"
 parking_lot = "0.12.5"
+slotmap = "1.1"
 
 serde = "1.0.228"
 

--- a/benihime-core/Cargo.toml
+++ b/benihime-core/Cargo.toml
@@ -25,3 +25,4 @@ unicode-general-category = "1.1.0"
 benihime-loader = {path = "../benihime-loader"}
 benihime-renderer = {path = "../benihime-renderer"}
 benihime-event = {path = "../benihime-event"}
+slotmap.workspace = true

--- a/benihime-core/src/application.rs
+++ b/benihime-core/src/application.rs
@@ -83,14 +83,14 @@ impl Application {
         let mut keymap = Keymap::new();
         keymap::default_keymap::register_default_keymap(&mut keymap);
 
-        let mut project_manager = ProjectManager::new();
+        let area = Rect::new(0, 0, 120, 40);
+        let mut project_manager = ProjectManager::new(area);
 
         if let Ok(dir) = paths::home_dir() {
             let projects_dir = dir.join("dev");
             project_manager.discover_in_path(&projects_dir);
         }
 
-        let area = Rect::new(0, 0, 120, 40);
         let mut composer = Composer::new(area);
 
         composer.push(Box::new(BufferLine::new()));
@@ -113,7 +113,7 @@ impl Application {
             "Welcome to Benihime!\n\nType something here...",
             None,
         );
-        editor.focused_buf_id = first_id;
+        editor.focus_buf(first_id);
 
         let mode = editor.mode();
 
@@ -406,6 +406,7 @@ impl benihime_renderer::Application for Application {
     fn resize(&mut self, width: u32, height: u32, renderer: &mut Renderer) {
         let area = Rect::new(0, 0, width as u16, height as u16);
         self.composer.resize(area);
+        self.editor.resize(area);
 
         let cell_height = renderer.cell_height() as usize;
         let cell_width = renderer.cell_width() as usize;

--- a/benihime-core/src/application.rs
+++ b/benihime-core/src/application.rs
@@ -8,24 +8,21 @@ use benihime_renderer::{
 use thiserror::Error;
 
 use crate::{
-    buffer::{BufferId, Mode},
-    buffer_manager::BufferManager,
     command::{self, command_registry::CommandRegistry},
-    editor::{Editor, EditorConfig},
+    editor::{Editor, EditorConfig, Mode},
     graphics::Rect,
     input_handler::InputHandler,
     keymap::{
         self, Keymap,
         key_chord::{KeyChord, KeyModifiers},
     },
-    mini_buffer::MiniBufferManager,
     project::project_manager::ProjectManager,
     theme::theme_loader::ThemeLoader,
     ui::{
-        components::buffer_line::BufferLine,
-        components::cursor::CursorComponent,
-        components::mini_buffer::MiniBufferComponent,
-        components::status_line::StatusLine,
+        components::{
+            buffer_line::BufferLine, cursor::CursorComponent, mini_buffer::MiniBufferComponent,
+            status_line::StatusLine,
+        },
         composer::{Composer, Context, Event},
         editor_view::EditorView,
         job::Jobs,
@@ -78,8 +75,6 @@ impl Application {
     pub fn new() -> Self {
         let loader = benihime_loader::Loader::new().unwrap();
 
-        let buffer_manager = BufferManager::new();
-
         let mut command_registry = CommandRegistry::new();
         command::default_commands::register_default_commands(&mut command_registry);
 
@@ -104,30 +99,19 @@ impl Application {
         composer.push(Box::new(CursorComponent::new()));
         composer.push(Box::new(MiniBufferComponent::new()));
 
-        let c = EditorConfig::default();
-        let mut editor = Editor {
-            focused_buf_id: BufferId(0),
+        let mut editor = Editor::new(
+            area,
+            theme_loader,
             project_manager,
-            buffer_manager,
-            command_buffer: String::new(),
-            message: None,
-            error_message: None,
-            screen_height: 0,
-            screen_width: 0,
-            minibuffer_manager: MiniBufferManager::new(),
-            registry: Arc::new(command_registry),
-            theme: theme_loader.default(),
-            theme_loader: Arc::new(theme_loader),
-            prefix_arg: None,
             keymap,
-            write_count: 0,
-            needs_redraw: false,
-            config: Arc::new(c),
-        };
+            Arc::new(command_registry),
+            Arc::new(EditorConfig::default()),
+        );
 
-        let first_id = editor.create_buffer_from_text(
+        let first_id = editor.new_buffer_from_text(
             "[No Name]",
             "Welcome to Benihime!\n\nType something here...",
+            None,
         );
         editor.focused_buf_id = first_id;
 
@@ -156,12 +140,9 @@ impl Application {
 
     pub fn handle_key(&mut self, key: Key, modifiers: KeyModifiers) {
         let state = &mut self.editor;
-        let buf_mode = {
-            let buf = state.focused_buf();
-            buf.mode
-        };
+        let mode = state.focus_ref().0.mode;
 
-        self.handle_key_with_mode(key, modifiers, buf_mode);
+        self.handle_key_with_mode(key, modifiers, mode);
     }
 
     pub fn handle_key_with_mode(&mut self, key: Key, modifiers: KeyModifiers, mode: Mode) {
@@ -191,14 +172,14 @@ impl Application {
 
         match buf_mode {
             Mode::Insert => {
-                let buf = state.focused_buf_mut();
+                let (window, buf) = state.focus();
                 let result = if chord.code == Key::Backspace {
-                    buf.delete_char_before_cursor();
+                    buf.delete_char_before_cursor(&mut window.cursor);
                     Ok(())
                 } else if chord.code == Key::Enter {
-                    buf.insert_char('\n')
+                    buf.insert_char('\n', &mut window.cursor)
                 } else if let Some(c) = chord.as_char() {
-                    buf.insert_char(c)
+                    buf.insert_char(c, &mut window.cursor)
                 } else {
                     Ok(())
                 };
@@ -549,9 +530,9 @@ impl Application {
             // commands::scroll(&mut cmd_cx, lines.unsigned_abs() as usize, direction, false);
         }
 
-        let focus = self.editor.focused_buf_mut();
+        let (window, _buf) = self.editor.focus();
 
-        focus.update_scroll(
+        window.update_scroll(
             lines as usize,
             config.scroll_offset,
             cols as usize,

--- a/benihime-core/src/buffer.rs
+++ b/benihime-core/src/buffer.rs
@@ -8,28 +8,28 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd)]
-pub struct Cursor {
+pub struct Position {
     pub row: usize,
     pub col: usize,
 }
 
-impl Cursor {
-    fn new() -> Cursor {
-        Cursor { row: 0, col: 0 }
+impl Position {
+    fn new() -> Position {
+        Position { row: 0, col: 0 }
     }
 
-    pub fn start() -> Cursor {
-        Cursor { row: 0, col: 0 }
+    pub fn start() -> Position {
+        Position { row: 0, col: 0 }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct Selection {
-    pub start: Cursor,
+    pub start: Position,
 }
 
 impl Selection {
-    pub fn normalized(&self, end: &Cursor) -> (Cursor, Cursor) {
+    pub fn normalized(&self, end: &Position) -> (Position, Position) {
         if self.start.row < end.row || self.start.row == end.row && self.start.col <= end.col {
             (self.start, *end)
         } else {
@@ -303,7 +303,7 @@ impl Buffer {
         }
     }
 
-    pub fn delete_selection(&mut self) -> Option<Cursor> {
+    pub fn delete_selection(&mut self) -> Option<Position> {
         if let Some(selection) = self.selection.take() {
             let (start, end) = selection.normalized(&self.cursor);
 

--- a/benihime-core/src/buffer.rs
+++ b/benihime-core/src/buffer.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Ok};
-use ropey::{iter::Lines, Rope, RopeSlice};
-use std::{io::Write, path::PathBuf, str::FromStr};
+use anyhow::{Ok, anyhow};
+use ropey::{Rope, RopeSlice, iter::Lines};
+use std::{io::Write, path::PathBuf};
 
 use crate::{
     movement::selection::Range,
@@ -38,15 +38,6 @@ impl Selection {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum Mode {
-    Normal,
-    Insert,
-    Visual,
-    Command,
-    Minibuffer,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct BufferId(pub u64);
 
@@ -56,29 +47,11 @@ impl std::fmt::Display for BufferId {
     }
 }
 
-impl FromStr for Mode {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "normal" => Ok(Mode::Normal),
-            "insert" => Ok(Mode::Insert),
-            "visual" => Ok(Mode::Visual),
-            "command" => Ok(Mode::Command),
-            _ => Err(anyhow!("Invalid mode: {}", s)),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Buffer {
     pub id: BufferId,
     lines: Rope,
     pub name: String,
-    pub cursor: Cursor,
-    pub scroll_offset: usize,
-    pub scroll_left: usize,
-    pub mode: Mode,
     pub file_path: Option<PathBuf>,
     pub selection: Option<Selection>,
     pub range: Option<Range>,
@@ -94,11 +67,7 @@ impl Buffer {
             id,
             name: name.to_string(),
             lines: Rope::new(),
-            cursor: Cursor::new(),
-            mode: Mode::Normal,
             file_path,
-            scroll_offset: 0,
-            scroll_left: 0,
             selection: None,
             range: None,
             undo_tree: UndoTree::new(),
@@ -119,11 +88,7 @@ impl Buffer {
             id,
             name: name.to_string(),
             lines: Rope::from_str(text),
-            cursor: Cursor::new(),
-            mode: Mode::Normal,
             file_path,
-            scroll_offset: 0,
-            scroll_left: 0,
             selection: None,
             range: None,
             undo_tree: UndoTree::new(),
@@ -181,8 +146,8 @@ impl Buffer {
         self.remove(start..end)
     }
 
-    pub fn get_cursor_to_char(&self) -> usize {
-        self.lines.line_to_char(self.cursor.row)
+    pub fn get_cursor_to_char(&self, row: usize) -> usize {
+        self.lines.line_to_char(row)
     }
 
     pub fn line_len(&self, row: usize) -> usize {
@@ -207,21 +172,21 @@ impl Buffer {
         }
     }
 
-    pub fn insert_char(&mut self, c: char) -> anyhow::Result<()> {
+    pub fn insert_char(&mut self, c: char, cursor: &mut Position) -> anyhow::Result<()> {
         if self.read_only {
             return Err(anyhow!("Buffer is read only"));
         }
         let mut s = String::new();
         s.push(c);
-        self.insert_str(&s)
+        self.insert_str(cursor, &s)
     }
 
-    pub fn insert_str(&mut self, s: &str) -> anyhow::Result<()> {
+    pub fn insert_str(&mut self, cursor: &mut Position, s: &str) -> anyhow::Result<()> {
         if self.read_only {
             return Err(anyhow!("Buffer is read only"));
         }
-        let row = self.cursor.row;
-        let col = self.cursor.col;
+        let row = cursor.row;
+        let col = cursor.col;
 
         if row >= self.lines.len_lines() {
             return Ok(());
@@ -246,18 +211,18 @@ impl Buffer {
         }
 
         if newlines > 0 {
-            self.cursor.row += newlines;
-            self.cursor.col = last_line_len;
+            cursor.row += newlines;
+            cursor.col = last_line_len;
         } else {
-            self.cursor.col = insert_col + last_line_len;
+            cursor.col = insert_col + last_line_len;
         }
 
         Ok(())
     }
 
-    pub fn delete_char_before_cursor(&mut self) {
-        let row = self.cursor.row;
-        let col = self.cursor.col;
+    pub fn delete_char_before_cursor(&mut self, cursor: &mut Position) {
+        let row = cursor.row;
+        let col = cursor.col;
 
         if row == 0 && col == 0 {
             return;
@@ -266,46 +231,21 @@ impl Buffer {
         if col > 0 {
             let char_idx = self.lines.line_to_char(row) + col - 1;
             self.remove(char_idx..char_idx + 1);
-            self.cursor.col -= 1;
+            cursor.col -= 1;
         } else {
             let prev_line_len = self.line_len(row - 1);
             let char_idx = self.lines.line_to_char(row);
             if char_idx > 0 {
                 self.remove(char_idx - 1..char_idx);
-                self.cursor.row -= 1;
-                self.cursor.col = prev_line_len;
+                cursor.row -= 1;
+                cursor.col = prev_line_len;
             }
         }
     }
 
-    pub fn update_scroll(
-        &mut self,
-        screen_height: usize,
-        vertical_scrolloff: usize,
-        screen_width: usize,
-        horizontal_scrolloff: usize,
-    ) {
-        let row = self.cursor.row;
-        let col = self.cursor.col;
-
-        if row < self.scroll_offset + vertical_scrolloff {
-            self.scroll_offset = row.saturating_sub(vertical_scrolloff);
-        }
-
-        if row >= self.scroll_offset + screen_height - vertical_scrolloff {
-            self.scroll_offset = row + vertical_scrolloff + 1 - screen_height;
-        }
-
-        if col < self.scroll_left + horizontal_scrolloff {
-            self.scroll_left = col.saturating_sub(horizontal_scrolloff);
-        } else if col >= self.scroll_left + screen_width - horizontal_scrolloff {
-            self.scroll_left = col.saturating_sub(screen_width - horizontal_scrolloff);
-        }
-    }
-
-    pub fn delete_selection(&mut self) -> Option<Position> {
+    pub fn delete_selection(&mut self, cursor: &mut Position) -> Option<Position> {
         if let Some(selection) = self.selection.take() {
-            let (start, end) = selection.normalized(&self.cursor);
+            let (start, end) = selection.normalized(&cursor);
 
             let start_char = self.lines.line_to_char(start.row) + start.col;
             let end_char = self.lines.line_to_char(end.row) + end.col;
@@ -314,29 +254,11 @@ impl Buffer {
                 self.remove(start_char..end_char);
             }
 
-            self.cursor = start;
+            *cursor = start;
             self.selection = None;
             Some(start)
         } else {
             None
-        }
-    }
-
-    pub fn center_cursor(&mut self, screen_height: usize) {
-        let cursor_row = self
-            .cursor
-            .row
-            .min(self.lines.len_lines().saturating_sub(1));
-
-        let half_screen = screen_height / 2;
-        if cursor_row >= half_screen {
-            self.scroll_offset = cursor_row - half_screen;
-        } else {
-            self.scroll_offset = 0;
-        }
-
-        if self.scroll_offset + screen_height > self.lines.len_lines() {
-            self.scroll_offset = self.lines.len_lines().saturating_sub(screen_height);
         }
     }
 
@@ -425,46 +347,6 @@ impl Buffer {
                 self.lines.insert(*at, text);
             }
         }
-    }
-
-    pub fn scroll_down(&mut self, lines: usize, screen_height: usize, scrolloff: usize) {
-        let max_row = self.line_count().saturating_sub(1);
-
-        let new_row = (self.cursor.row + lines).min(max_row);
-        self.cursor.row = new_row;
-
-        if new_row >= self.scroll_offset + screen_height - scrolloff {
-            self.scroll_offset = new_row + scrolloff + 1 - screen_height;
-        }
-        self.scroll_offset = self
-            .scroll_offset
-            .min(max_row.saturating_add(1).saturating_sub(screen_height));
-    }
-
-    pub fn scroll_up(&mut self, lines: usize, scrolloff: usize) {
-        let new_row = self.cursor.row.saturating_sub(lines);
-        self.cursor.row = new_row;
-
-        if new_row < self.scroll_offset + scrolloff {
-            self.scroll_offset = new_row.saturating_sub(scrolloff);
-        }
-    }
-
-    pub fn goto_first_line(&mut self) {
-        self.cursor.row = 0;
-        self.cursor.col = 0;
-        self.selection = None;
-        self.scroll_offset = 0;
-    }
-
-    pub fn goto_last_line(&mut self) {
-        let last_row = self.line_count().saturating_sub(1);
-        self.cursor.row = last_row;
-
-        let line_len = self.line_len(last_row);
-        self.cursor.col = self.cursor.col.min(line_len);
-
-        self.selection = None;
     }
 
     pub fn save(&mut self) -> anyhow::Result<()> {

--- a/benihime-core/src/command/default_commands.rs
+++ b/benihime-core/src/command/default_commands.rs
@@ -9,11 +9,12 @@ use ignore::Walk;
 
 use crate::{
     application::HandleKeyError,
-    buffer::{Buffer, Mode, Selection},
+    buffer::{Buffer, Position, Selection},
+    editor::{Editor, Mode},
     mini_buffer::{MiniBuffer, MinibufferCallbackResult},
+    movement::movement_commands,
     project::Project,
 };
-use crate::{editor::Editor, movement::movement_commands};
 
 use super::{
     command_registry::CommandRegistry,
@@ -22,9 +23,9 @@ use super::{
 
 pub fn register_default_commands(registry: &mut CommandRegistry) {
     registry.register("move-left", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
+        let (window, buf) = ctx.editor.focus();
         for _ in 0..ctx.count {
-            buf.cursor.col = buf.cursor.col.saturating_sub(1);
+            window.cursor.col = window.cursor.col.saturating_sub(1);
         }
         ctx.editor.update_scroll();
         Ok(())
@@ -33,15 +34,15 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
     registry.register("move-down", |ctx: &mut CommandContext| {
         let screen_height = ctx.editor.screen_height;
         let scroll_offset = ctx.editor.config.scroll_offset;
-        let buf = ctx.editor.focused_buf_mut();
+        let (window, buf) = ctx.editor.focus();
 
         for _ in 0..ctx.count {
-            buf.cursor.row = min(buf.cursor.row + 1, buf.line_count() - 1);
-            buf.cursor.col = min(buf.cursor.col, buf.line_len(buf.cursor.row));
+            window.cursor.row = min(window.cursor.row + 1, buf.line_count() - 1);
+            window.cursor.col = min(window.cursor.col, buf.line_len(window.cursor.row));
         }
 
-        if buf.cursor.row >= buf.scroll_offset + screen_height - scroll_offset {
-            buf.scroll_offset = buf.cursor.row + scroll_offset + 1 - screen_height;
+        if window.cursor.row >= window.scroll_offset + screen_height - scroll_offset {
+            window.scroll_offset = window.cursor.row + scroll_offset + 1 - screen_height;
         }
 
         Ok(())
@@ -49,24 +50,24 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
 
     registry.register("move-up", |ctx: &mut CommandContext| {
         let scroll_offset = ctx.editor.config.scroll_offset;
-        let buf = ctx.editor.focused_buf_mut();
+        let (window, buf) = ctx.editor.focus();
 
         for _ in 0..ctx.count {
-            buf.cursor.row = buf.cursor.row.saturating_sub(1);
-            buf.cursor.col = min(buf.cursor.col, buf.line_len(buf.cursor.row));
+            window.cursor.row = window.cursor.row.saturating_sub(1);
+            window.cursor.col = min(window.cursor.col, buf.line_len(window.cursor.row));
         }
 
-        if buf.cursor.row < buf.scroll_offset + scroll_offset {
-            buf.scroll_offset = buf.cursor.row.saturating_sub(scroll_offset);
+        if window.cursor.row < window.scroll_offset + scroll_offset {
+            window.scroll_offset = window.cursor.row.saturating_sub(scroll_offset);
         }
 
         Ok(())
     });
 
     registry.register("move-right", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
+        let (window, buf) = ctx.editor.focus();
         for _ in 0..ctx.count {
-            buf.cursor.col = min(buf.cursor.col + 1, buf.line_len(buf.cursor.row));
+            window.cursor.col = min(window.cursor.col + 1, buf.line_len(window.cursor.row));
         }
         ctx.editor.update_scroll();
         Ok(())
@@ -78,33 +79,33 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             ctx.editor.command_buffer.clear();
         }
 
-        let buf = ctx.editor.focused_buf_mut();
-        if buf.mode != Mode::Insert && mode == Mode::Insert {
+        let (window, buf) = ctx.editor.focus();
+        if window.mode != Mode::Insert && mode == Mode::Insert {
             buf.undo_tree.commit_group();
         }
 
-        buf.mode = mode;
+        window.mode = mode;
 
         Ok(())
     });
 
     registry.register("beginning-of-line", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        buf.cursor.col = 0;
+        let (window, buf) = ctx.editor.focus();
+        window.cursor.col = 0;
         ctx.editor.update_scroll();
         Ok(())
     });
 
     registry.register("end-of-line", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        buf.cursor.col = buf.line_len(buf.cursor.row);
+        let (window, buf) = ctx.editor.focus();
+        window.cursor.col = buf.line_len(window.cursor.row);
         ctx.editor.update_scroll();
         Ok(())
     });
 
     registry.register("first-non-blank", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        let line = buf.line(buf.cursor.row);
+        let (window, buf) = ctx.editor.focus();
+        let line = buf.line(window.cursor.row);
         let mut i = 0;
         for (idx, char) in line.chars().enumerate() {
             if !char.is_whitespace() {
@@ -113,27 +114,28 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             }
             i = idx + 1;
         }
-        buf.cursor.col = i;
+        window.cursor.col = i;
         ctx.editor.update_scroll();
         Ok(())
     });
 
     registry.register("open-above", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        let char_idx = buf.get_cursor_to_char();
+        let (window, buf) = ctx.editor.focus();
+        let char_idx = buf.get_line_to_char(window.cursor.row);
         buf.insert_idx(char_idx, "\n")?;
-        buf.cursor.col = 0;
+        window.cursor.row = window.cursor.row.saturating_sub(1);
+        window.cursor.col = 0;
         ctx.editor
             .exec("set-mode", Some(vec![CommandArg::Mode(Mode::Insert)]))?;
         Ok(())
     });
 
     registry.register("open-below", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        let char_idx = buf.get_line_to_char(buf.cursor.row + 1);
+        let (window, buf) = ctx.editor.focus();
+        let char_idx = buf.get_line_to_char(window.cursor.row + 1);
         buf.insert_idx(char_idx, "\n")?;
-        buf.cursor.row += 1;
-        buf.cursor.col = 0;
+        window.cursor.row += 1;
+        window.cursor.col = 0;
 
         ctx.editor
             .exec("set-mode", Some(vec![CommandArg::Mode(Mode::Insert)]))?;
@@ -410,8 +412,8 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
     });
     registry.register("center-cursor", |ctx: &mut CommandContext| {
         let screen_height = ctx.editor.screen_height;
-        let buf = ctx.editor.focused_buf_mut();
-        buf.center_cursor(screen_height);
+        let (window, buf) = ctx.editor.focus();
+        window.center_cursor(screen_height, buf.line_count());
         Ok(())
     });
 
@@ -489,51 +491,53 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
     });
 
     registry.register("enter-visual-mode", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        if buf.mode != Mode::Visual {
-            buf.selection = Some(Selection { start: buf.cursor });
-            buf.mode = Mode::Visual;
+        let (window, buf) = ctx.editor.focus();
+        if window.mode != Mode::Visual {
+            buf.selection = Some(Selection {
+                start: window.cursor,
+            });
+            window.mode = Mode::Visual;
         }
         Ok(())
     });
 
     registry.register("exit-visual-mode", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
+        let (window, buf) = ctx.editor.focus();
         buf.selection = None;
-        buf.mode = Mode::Normal;
+        window.mode = Mode::Normal;
         Ok(())
     });
 
     registry.register("visual_select_other_end", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        if buf.mode == Mode::Visual
+        let (window, buf) = ctx.editor.focus();
+        if window.mode == Mode::Visual
             && let Some(selection) = &mut buf.selection
         {
-            std::mem::swap(&mut selection.start, &mut buf.cursor);
+            std::mem::swap(&mut selection.start, &mut window.cursor);
         }
         Ok(())
     });
 
     registry.register("delete-selection", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        if buf.mode == Mode::Visual {
-            buf.delete_selection();
-            buf.mode = Mode::Normal;
+        let (window, buf) = ctx.editor.focus();
+        if window.mode == Mode::Visual {
+            buf.delete_selection(&mut window.cursor);
+            window.mode = Mode::Normal;
         }
         Ok(())
     });
 
     registry.register("change-selection", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        if buf.mode == Mode::Visual {
-            buf.delete_selection();
-            buf.mode = Mode::Insert;
+        let (window, buf) = ctx.editor.focus();
+        if window.mode == Mode::Visual {
+            buf.delete_selection(&mut window.cursor);
+            window.mode = Mode::Insert;
         }
         Ok(())
     });
 
     registry.register("find-buffer", |ctx: &mut CommandContext| {
-        let buffers = ctx.editor.buffer_manager.get_buffers_cloned();
+        let buffers = ctx.editor.get_buffers_cloned();
 
         let minibuffer: MiniBuffer<Buffer> = MiniBuffer::new(
             "Find Buffer: ",
@@ -553,8 +557,8 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
     });
 
     registry.register_operator("delete-range", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        let row = buf.cursor.row;
+        let (window, buf) = ctx.editor.focus();
+        let row = window.cursor.row;
         let line_start = buf.get_line_to_char(row);
         let line_end = buf.get_line_to_char(row + 1);
         let line_len = line_end - line_start;
@@ -565,9 +569,9 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             let del_start = line_start + start.min(line_len);
             let del_end = line_start + end.min(line_len);
             buf.remove_line(del_start, del_end);
-            buf.cursor.col = start;
+            window.cursor.col = start;
         } else if line_len > 0 {
-            let col = buf.cursor.col.min(line_len.saturating_sub(1));
+            let col = window.cursor.col.min(line_len.saturating_sub(1));
             let del_start = line_start + col;
             let del_end = del_start + 1;
             buf.remove_line(del_start, del_end);
@@ -577,8 +581,8 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
     });
 
     registry.register_operator("change-range", |ctx: &mut CommandContext| {
-        let buf = ctx.editor.focused_buf_mut();
-        let row = buf.cursor.row;
+        let (window, buf) = ctx.editor.focus();
+        let row = window.cursor.row;
         let line_start = buf.get_line_to_char(row);
         let line_end = buf.get_line_to_char(row + 1);
         let line_len = line_end - line_start;
@@ -589,8 +593,8 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             let del_start = line_start + start.min(line_len);
             let del_end = line_start + end.min(line_len);
             buf.remove_line(del_start, del_end);
-            buf.cursor.col = start;
-            buf.mode = Mode::Insert;
+            window.cursor.col = start;
+            window.mode = Mode::Insert;
         }
 
         Ok(())
@@ -614,13 +618,13 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
 
     registry.register("undo-tree-show", |ctx| {
         let tree_text = {
-            let buf = ctx.editor.focused_buf();
+            let buf = ctx.editor.focus_ref().1;
             buf.undo_tree.render()
         };
 
         let id = ctx
             .editor
-            .create_read_only_buffer_from_text("*undo-tree*", &tree_text);
+            .new_read_only_buffer_from_text("*undo-tree*", &tree_text);
 
         ctx.editor.focused_buf_id = id;
         Ok(())
@@ -629,45 +633,57 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
     registry.register("scroll-half-down", |ctx| {
         let screen_height = ctx.editor.screen_height;
         let scroll_offset = ctx.editor.config.scroll_offset;
-        let buf = ctx.editor.focused_buf_mut();
+        let (window, buf) = ctx.editor.focus();
         let h = screen_height / 2;
-        buf.scroll_down(h, screen_height, scroll_offset);
+        window.scroll_down(buf.line_count(), h, screen_height, scroll_offset);
         Ok(())
     });
 
     registry.register("scroll-half-up", |ctx| {
         let screen_height = ctx.editor.screen_height;
         let scroll_offset = ctx.editor.config.scroll_offset;
-        let buf = ctx.editor.focused_buf_mut();
+        let window = ctx.editor.focus().0;
         let h = screen_height / 2;
-        buf.scroll_up(h, scroll_offset);
+        window.scroll_up(h, scroll_offset);
         Ok(())
     });
 
     registry.register("scroll-full-down", |ctx| {
         let screen_height = ctx.editor.screen_height;
         let scroll_offset = ctx.editor.config.scroll_offset;
-        let buf = ctx.editor.focused_buf_mut();
-        buf.scroll_down(screen_height, screen_height, scroll_offset);
+        let (window, buf) = ctx.editor.focus();
+        window.scroll_down(
+            buf.line_count(),
+            screen_height,
+            screen_height,
+            scroll_offset,
+        );
         Ok(())
     });
 
     registry.register("scroll-full-up", |ctx| {
         let screen_height = ctx.editor.screen_height;
         let scroll_offset = ctx.editor.config.scroll_offset;
-        let buf = ctx.editor.focused_buf_mut();
-        buf.scroll_up(screen_height, scroll_offset);
+        let window = ctx.editor.focus().0;
+        window.scroll_up(screen_height, scroll_offset);
         Ok(())
     });
     registry.register("goto-first-line", |ctx| {
-        let buf = ctx.editor.focused_buf_mut();
-        buf.goto_first_line();
+        let (window, buf) = ctx.editor.focus();
+        window.cursor = Position::start();
+        buf.selection = None;
+        window.scroll_offset = 0;
         Ok(())
     });
 
     registry.register("goto-last-line", |ctx| {
-        let buf = ctx.editor.focused_buf_mut();
-        buf.goto_last_line();
+        let (window, buf) = ctx.editor.focus();
+        let last_row = buf.line_count().saturating_sub(1);
+
+        let line_len = buf.line_len(last_row);
+
+        window.cursor.col = window.cursor.col.min(line_len);
+        buf.selection = None;
         Ok(())
     });
 
@@ -714,25 +730,25 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
 
         let id = ctx
             .editor
-            .create_read_only_buffer_from_text("*keymap*", &tree_text);
+            .new_read_only_buffer_from_text("*keymap*", &tree_text);
 
         ctx.editor.focused_buf_id = id;
         Ok(())
     });
 
     registry.register("live-grep", |ctx| {
-        let buf = ctx.editor.focused_buf();
+        let buf = ctx.editor.focus_ref().1;
         let content = buf.to_string();
 
         let items: Vec<String> = content.lines().map(|s| s.to_string()).collect();
 
         let minibuffer: MiniBuffer<String> =
             MiniBuffer::new("Search: ", items, |state: &mut Editor, line: &String| {
-                let buf = state.focused_buf_mut();
+                let (window, buf) = state.focus();
                 for (i, l) in buf.to_string().lines().enumerate() {
                     if l == line {
-                        buf.cursor.row = i;
-                        buf.cursor.col = 0;
+                        window.cursor.row = i;
+                        window.cursor.col = 0;
                         break;
                     }
                 }

--- a/benihime-core/src/command/default_commands.rs
+++ b/benihime-core/src/command/default_commands.rs
@@ -14,6 +14,7 @@ use crate::{
     mini_buffer::{MiniBuffer, MinibufferCallbackResult},
     movement::movement_commands,
     project::Project,
+    tree::Layout,
 };
 
 use super::{
@@ -410,6 +411,17 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
 
         Ok(())
     });
+
+    registry.register("split-window-horizontal", |ctx: &mut CommandContext| {
+        ctx.editor.split_current_buffer(Layout::Horizontal);
+        Ok(())
+    });
+
+    registry.register("split-window-vertical", |ctx: &mut CommandContext| {
+        ctx.editor.split_current_buffer(Layout::Vertical);
+        Ok(())
+    });
+
     registry.register("center-cursor", |ctx: &mut CommandContext| {
         let screen_height = ctx.editor.screen_height;
         let (window, buf) = ctx.editor.focus();

--- a/benihime-core/src/command/default_commands.rs
+++ b/benihime-core/src/command/default_commands.rs
@@ -303,7 +303,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
                     return Ok(Some(new_items));
                 } else {
                     let id = state.open_file(&path.clone());
-                    state.focused_buf_id = id;
+                    state.focus_buf(id);
                     println!("Opened file: {}", path.display());
                 }
                 Ok(None)
@@ -335,7 +335,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             files,
             |state: &mut Editor, path: &PathBuf| {
                 let id = state.open_file(&path.clone());
-                state.focused_buf_id = id;
+                state.focus_buf(id);
                 Ok(None)
             },
         );
@@ -387,7 +387,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             None => ids[0],
         };
 
-        state.focused_buf_id = next;
+        state.focus_buf(next);
 
         Ok(())
     });
@@ -406,7 +406,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             None => ids[0],
         };
 
-        state.focused_buf_id = prev;
+        state.focus_buf(prev);
 
         Ok(())
     });
@@ -543,7 +543,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             "Find Buffer: ",
             buffers,
             |state: &mut Editor, command_name: &Buffer| {
-                state.focused_buf_id = command_name.id;
+                state.focus_buf(command_name.id);
                 Ok(None)
             },
         );
@@ -626,7 +626,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             .editor
             .new_read_only_buffer_from_text("*undo-tree*", &tree_text);
 
-        ctx.editor.focused_buf_id = id;
+        ctx.editor.focus_buf(id);
         Ok(())
     });
 
@@ -732,7 +732,7 @@ pub fn register_default_commands(registry: &mut CommandRegistry) {
             .editor
             .new_read_only_buffer_from_text("*keymap*", &tree_text);
 
-        ctx.editor.focused_buf_id = id;
+        ctx.editor.focus_buf(id);
         Ok(())
     });
 

--- a/benihime-core/src/command/mod.rs
+++ b/benihime-core/src/command/mod.rs
@@ -4,7 +4,7 @@ pub mod default_commands;
 use anyhow::{Result, anyhow};
 use std::path::PathBuf;
 
-use crate::{buffer::Mode, editor::Editor};
+use crate::editor::{Editor, Mode};
 
 #[derive(Debug, Clone)]
 pub enum CommandArg {
@@ -23,9 +23,10 @@ impl CommandArg {
         }
 
         if let Some((row_str, col_str)) = token.split_once(',')
-            && let (Ok(row), Ok(col)) = (row_str.parse::<usize>(), col_str.parse::<usize>()) {
-                return CommandArg::Position { row, col };
-            }
+            && let (Ok(row), Ok(col)) = (row_str.parse::<usize>(), col_str.parse::<usize>())
+        {
+            return CommandArg::Position { row, col };
+        }
 
         if let Ok(mode) = token.parse::<Mode>() {
             return CommandArg::Mode(mode);
@@ -111,8 +112,8 @@ impl ArgAsOwned<bool> for CommandArg {
     }
 }
 
-impl ArgAsOwned<crate::buffer::Mode> for CommandArg {
-    fn as_type_owned(&self) -> Option<crate::buffer::Mode> {
+impl ArgAsOwned<crate::editor::Mode> for CommandArg {
+    fn as_type_owned(&self) -> Option<crate::editor::Mode> {
         match self {
             CommandArg::Mode(m) => Some(*m),
             _ => None,

--- a/benihime-core/src/editor.rs
+++ b/benihime-core/src/editor.rs
@@ -55,7 +55,6 @@ pub struct Editor {
     pub prefix_arg: Option<usize>,
     pub keymap: Keymap,
 
-    tree: Tree,
     buffers: BTreeMap<BufferId, Buffer>,
     next_buffer_id: BufferId,
 
@@ -67,7 +66,7 @@ pub struct Editor {
 
 impl Editor {
     pub fn new(
-        area: Rect,
+        _area: Rect,
         theme_loader: ThemeLoader,
         project_manager: ProjectManager,
 
@@ -92,10 +91,21 @@ impl Editor {
             write_count: 0,
             needs_redraw: false,
             config,
-            tree: Tree::new(area),
             buffers: BTreeMap::new(),
             next_buffer_id: BufferId(1),
         }
+    }
+
+    pub fn tree(&self) -> &Tree {
+        &self.project_manager.current().tree
+    }
+
+    pub fn tree_mut(&mut self) -> &mut Tree {
+        &mut self.project_manager.current_mut().tree
+    }
+
+    pub fn resize(&mut self, area: Rect) {
+        self.project_manager.resize(area);
     }
 
     pub fn cwd(&self) -> Option<&PathBuf> {
@@ -149,14 +159,15 @@ impl Editor {
         }
 
         project.buffers.retain(|&id| id != buf_id_to_kill);
+        project.windows.remove(&buf_id_to_kill);
 
         self.buffers.remove(&buf_id_to_kill);
 
         if let Some(&new_focus) = project.buffers.last() {
-            self.focused_buf_id = new_focus;
+            self.focus_buf(new_focus);
         } else {
             let new_buf = self.new_empty_buffer("[No Name]");
-            self.focused_buf_id = new_buf;
+            self.focus_buf(new_buf);
         }
 
         Ok(())
@@ -188,13 +199,13 @@ impl Editor {
     }
 
     pub fn switch_project(&mut self, project_id: ProjectId) {
-        let project = self.project_manager.switch_by_id(project_id);
-        if let Some(project) = project {
-            if project.buffers.is_empty() {
-                let buf = self.new_empty_buffer("[No Name]");
-                self.focused_buf_id = buf;
+        if self.project_manager.switch_by_id(project_id).is_some() {
+            let buffer_id = self.project_manager.current().buffers.first().copied();
+            if let Some(buffer_id) = buffer_id {
+                self.focus_buf(buffer_id);
             } else {
-                self.focused_buf_id = project.buffers[0];
+                let buf = self.new_empty_buffer("[No Name]");
+                self.focus_buf(buf);
             }
         }
     }
@@ -226,9 +237,9 @@ impl Editor {
 
             if last_project.buffers.is_empty() {
                 let new_buf = self.new_empty_buffer("[No Name]");
-                self.focused_buf_id = new_buf;
+                self.focus_buf(new_buf);
             } else {
-                self.focused_buf_id = last_project.buffers[0];
+                self.focus_buf(last_project.buffers[0]);
             }
         }
 
@@ -259,9 +270,9 @@ impl Editor {
 
         if project.buffers.is_empty() {
             let buf = self.new_empty_buffer("[No Name]");
-            self.focused_buf_id = buf;
+            self.focus_buf(buf);
         } else {
-            self.focused_buf_id = project.buffers[0];
+            self.focus_buf(project.buffers[0]);
         }
     }
 
@@ -317,24 +328,30 @@ impl Editor {
     }
 
     pub fn focused_buf_mut(&mut self) -> &mut Buffer {
+        let focused_buf_id = self.focus_ref().1.id;
         self.buffers
-            .get_mut(&self.focused_buf_id)
+            .get_mut(&focused_buf_id)
             .expect("Focused buffer not exist")
     }
 
     pub fn focus(&mut self) -> (&mut Window, &mut Buffer) {
-        let view = self.tree.get_mut(self.tree.focus);
-        let buf = self
-            .buffers
-            .get_mut(&self.focused_buf_id)
+        let project_manager = &mut self.project_manager;
+        let buffers = &mut self.buffers;
+        let tree = &mut project_manager.current_mut().tree;
+        let focus = tree.focus;
+        let view = tree.get_mut(focus);
+        let buffer_id = view.buffer_id;
+        let buf = buffers
+            .get_mut(&buffer_id)
             .expect("Focus buffer didn't found");
 
         return (view, buf);
     }
 
     pub fn focus_ref(&self) -> (&Window, &Buffer) {
-        let view = self.tree.get(self.tree.focus);
-        let buf = &self.buffers[&self.focused_buf_id];
+        let tree = &self.project_manager.current().tree;
+        let view = tree.get(tree.focus);
+        let buf = &self.buffers[&view.buffer_id];
 
         return (view, buf);
     }
@@ -353,8 +370,30 @@ impl Editor {
     }
 
     pub fn focus_buf(&mut self, buf_id: BufferId) {
-        let id = self.tree.insert(Window::new(buf_id));
-        self.tree.focus = id;
+        let current_window = {
+            let tree = self.tree();
+            tree.try_get(tree.focus).cloned()
+        };
+
+        let project = self.project_manager.current_mut();
+
+        if let Some(window) = current_window {
+            project.windows.insert(window.buffer_id, window);
+        }
+
+        let window = project
+            .windows
+            .get(&buf_id)
+            .cloned()
+            .unwrap_or_else(|| Window::new(buf_id));
+
+        self.focused_buf_id = buf_id;
+        project.tree.set_single_window(window);
+    }
+
+    #[inline]
+    pub fn buf(&self, id: BufferId) -> Option<&Buffer> {
+        self.buffers.get(&id)
     }
 }
 

--- a/benihime-core/src/editor.rs
+++ b/benihime-core/src/editor.rs
@@ -13,7 +13,7 @@ use crate::{
         project_manager::{DEFAULT_PROJECT_ID, ProjectManager},
     },
     theme::{Theme, theme_loader::ThemeLoader},
-    tree::Tree,
+    tree::{Layout, Tree},
     window::Window,
 };
 
@@ -389,6 +389,14 @@ impl Editor {
 
         self.focused_buf_id = buf_id;
         project.tree.set_single_window(window);
+    }
+
+    pub fn split_current_buffer(&mut self, layout: Layout) {
+        let window = self.focus_ref().0.clone();
+        self.project_manager
+            .current_mut()
+            .tree
+            .split(window, layout);
     }
 
     #[inline]

--- a/benihime-core/src/editor.rs
+++ b/benihime-core/src/editor.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, fs, path::PathBuf, str::FromStr, sync::Arc};
 
 use crate::{
     application::HandleKeyError,
-    buffer::{Buffer, BufferId, Mode},
-    buffer_manager::BufferManager,
+    buffer::{Buffer, BufferId},
     command::{CommandArg, CommandContext, command_registry::CommandRegistry},
+    graphics::Rect,
     keymap::Keymap,
     mini_buffer::MiniBufferManager,
     project::{
@@ -13,12 +13,36 @@ use crate::{
         project_manager::{DEFAULT_PROJECT_ID, ProjectManager},
     },
     theme::{Theme, theme_loader::ThemeLoader},
+    tree::Tree,
+    window::Window,
 };
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Mode {
+    Normal,
+    Insert,
+    Visual,
+    Command,
+    Minibuffer,
+}
+
+impl FromStr for Mode {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "normal" => Ok(Mode::Normal),
+            "insert" => Ok(Mode::Insert),
+            "visual" => Ok(Mode::Visual),
+            "command" => Ok(Mode::Command),
+            _ => Err(anyhow!("Invalid mode: {}", s)),
+        }
+    }
+}
 
 pub struct Editor {
     pub focused_buf_id: BufferId,
     pub project_manager: ProjectManager,
-    pub buffer_manager: BufferManager,
     pub minibuffer_manager: MiniBufferManager,
     pub screen_height: usize,
     pub screen_width: usize,
@@ -26,45 +50,61 @@ pub struct Editor {
     pub message: Option<String>,
     pub error_message: Option<String>,
     pub registry: Arc<CommandRegistry>,
-    pub theme: Theme,
-    pub theme_loader: Arc<ThemeLoader>,
+    theme: Theme,
+    theme_loader: Arc<ThemeLoader>,
     pub prefix_arg: Option<usize>,
     pub keymap: Keymap,
 
-    pub write_count: usize,
+    tree: Tree,
+    buffers: BTreeMap<BufferId, Buffer>,
+    next_buffer_id: BufferId,
+
+    write_count: usize,
 
     pub needs_redraw: bool,
     pub config: Arc<EditorConfig>,
 }
 
 impl Editor {
+    pub fn new(
+        area: Rect,
+        theme_loader: ThemeLoader,
+        project_manager: ProjectManager,
+
+        keymap: Keymap,
+        registry: Arc<CommandRegistry>,
+        config: Arc<EditorConfig>,
+    ) -> Self {
+        Self {
+            focused_buf_id: BufferId(0),
+            project_manager,
+            command_buffer: String::new(),
+            message: None,
+            error_message: None,
+            screen_height: 0,
+            screen_width: 0,
+            minibuffer_manager: MiniBufferManager::new(),
+            registry,
+            theme: theme_loader.default(),
+            theme_loader: Arc::new(theme_loader),
+            prefix_arg: None,
+            keymap,
+            write_count: 0,
+            needs_redraw: false,
+            config,
+            tree: Tree::new(area),
+            buffers: BTreeMap::new(),
+            next_buffer_id: BufferId(1),
+        }
+    }
+
     pub fn cwd(&self) -> Option<&PathBuf> {
         self.project_manager.current().root.as_ref()
     }
 
-    pub fn focused_buf_mut(&mut self) -> &mut Buffer {
-        self.buffer_manager
-            .get_buffer_mut(self.focused_buf_id)
-            .expect("Focused buffer must exist")
-    }
-
-    pub fn focused_buf(&self) -> &Buffer {
-        self.buffer_manager
-            .get_buffer(self.focused_buf_id)
-            .expect("Focused buffer must exist")
-    }
-
-    pub fn update_scroll(&mut self) {
-        let screen_height = self.screen_height;
-        let screen_width = self.screen_width;
-        let scroll_offset = self.config.scroll_offset;
-        let buf = self.focused_buf_mut();
-        buf.update_scroll(screen_height, scroll_offset, screen_width, scroll_offset);
-    }
-
     pub fn status_line(&self) -> String {
-        let buf = self.buffer_manager.get_buffer(self.focused_buf_id).unwrap();
-        let mode = match buf.mode {
+        let (window, buf) = self.focus_ref();
+        let mode = match window.mode {
             Mode::Normal => "NORMAL",
             Mode::Insert => "INSERT",
             Mode::Visual => "VISUAL",
@@ -79,7 +119,7 @@ impl Editor {
             .current()
             .buffers
             .iter()
-            .filter_map(|f| self.buffer_manager.get_buffer(*f))
+            .filter_map(|f| self.buffers.get(f))
             .map(|buf| {
                 let is_active = buf.id == self.focused_buf_id;
                 (buf.id, buf.name.clone(), is_active, buf.is_modified())
@@ -97,8 +137,8 @@ impl Editor {
         let buf_id_to_kill = self.focused_buf_id;
 
         let buf = self
-            .buffer_manager
-            .get_buffer(buf_id_to_kill)
+            .buffers
+            .get(&buf_id_to_kill)
             .ok_or_else(|| anyhow!("Buffer not found"))?;
 
         if buf.is_modified() {
@@ -110,12 +150,12 @@ impl Editor {
 
         project.buffers.retain(|&id| id != buf_id_to_kill);
 
-        self.buffer_manager.kill_buffer(buf_id_to_kill);
+        self.buffers.remove(&buf_id_to_kill);
 
         if let Some(&new_focus) = project.buffers.last() {
             self.focused_buf_id = new_focus;
         } else {
-            let new_buf = self.create_empty_buffer("[No Name]");
+            let new_buf = self.new_empty_buffer("[No Name]");
             self.focused_buf_id = new_buf;
         }
 
@@ -142,7 +182,7 @@ impl Editor {
                 count,
             },
         )?;
-        
+
         self.needs_redraw = true;
         Ok(())
     }
@@ -151,7 +191,7 @@ impl Editor {
         let project = self.project_manager.switch_by_id(project_id);
         if let Some(project) = project {
             if project.buffers.is_empty() {
-                let buf = self.create_empty_buffer("[No Name]");
+                let buf = self.new_empty_buffer("[No Name]");
                 self.focused_buf_id = buf;
             } else {
                 self.focused_buf_id = project.buffers[0];
@@ -159,30 +199,10 @@ impl Editor {
         }
     }
 
-    pub fn create_empty_buffer(&mut self, name: &str) -> BufferId {
-        let id = self.buffer_manager.create_empty_buffer(name);
-        self.project_manager.add_buffer_to_current(id);
-        id
-    }
-
-    pub fn create_buffer_from_text(&mut self, name: &str, text: &str) -> BufferId {
-        let id = self.buffer_manager.create_buffer_from(name, text, None);
-
-        self.project_manager.add_buffer_to_current(id);
-        id
-    }
-
-    pub fn create_read_only_buffer_from_text(&mut self, name: &str, text: &str) -> BufferId {
-        let id = self.buffer_manager.create_read_only_buffer_from(name, text);
-
-        self.project_manager.add_buffer_to_current(id);
-        id
-    }
-
     pub fn open_file(&mut self, path: &PathBuf) -> BufferId {
         let contents = fs::read_to_string(path).unwrap_or_default();
 
-        let id = self.buffer_manager.create_buffer_from(
+        let id = self.new_buffer_from_text(
             path.file_name().unwrap().to_str().unwrap(),
             &contents,
             Some(path),
@@ -195,19 +215,17 @@ impl Editor {
     pub fn close_current_project(&mut self) -> anyhow::Result<()> {
         let id = self.project_manager.current_id();
 
-        let killed_buffers = self
-            .project_manager
-            .close_project(id, &mut self.buffer_manager)?;
+        let killed_buffers = self.project_manager.close_project(id)?;
 
         for buf_id in &killed_buffers {
-            self.buffer_manager.kill_buffer(*buf_id);
+            self.buffers.remove(buf_id);
         }
 
         if self.project_manager.current_id() == DEFAULT_PROJECT_ID {
             let last_project = self.project_manager.current();
 
             if last_project.buffers.is_empty() {
-                let new_buf = self.create_empty_buffer("[No Name]");
+                let new_buf = self.new_empty_buffer("[No Name]");
                 self.focused_buf_id = new_buf;
             } else {
                 self.focused_buf_id = last_project.buffers[0];
@@ -240,7 +258,7 @@ impl Editor {
         let project = self.project_manager.current();
 
         if project.buffers.is_empty() {
-            let buf = self.create_empty_buffer("[No Name]");
+            let buf = self.new_empty_buffer("[No Name]");
             self.focused_buf_id = buf;
         } else {
             self.focused_buf_id = project.buffers[0];
@@ -264,7 +282,79 @@ impl Editor {
     }
 
     pub fn mode(&self) -> Mode {
-        self.focused_buf().mode
+        self.focus_ref().0.mode
+    }
+
+    pub fn new_empty_buffer(&mut self, name: &str) -> BufferId {
+        let buf = Buffer::new(BufferId(0), name, None, false);
+        self.new_buffer(buf)
+    }
+
+    pub fn new_read_only_buffer_from_text(&mut self, name: &str, text: &str) -> BufferId {
+        let buf = Buffer::from(BufferId(0), name, text, None, true);
+        self.new_buffer(buf)
+    }
+
+    pub fn new_buffer_from_text(
+        &mut self,
+        name: &str,
+        text: &str,
+        file_path: Option<&PathBuf>,
+    ) -> BufferId {
+        let buf = Buffer::from(BufferId(0), name, text, file_path.cloned(), false);
+        self.new_buffer(buf)
+    }
+
+    fn new_buffer(&mut self, mut buf: Buffer) -> BufferId {
+        let id = BufferId(self.next_buffer_id.0);
+        self.next_buffer_id = BufferId(self.next_buffer_id.0 + 1);
+        buf.id = id;
+
+        self.buffers.insert(id, buf);
+        self.focus_buf(id);
+
+        id
+    }
+
+    pub fn focused_buf_mut(&mut self) -> &mut Buffer {
+        self.buffers
+            .get_mut(&self.focused_buf_id)
+            .expect("Focused buffer not exist")
+    }
+
+    pub fn focus(&mut self) -> (&mut Window, &mut Buffer) {
+        let view = self.tree.get_mut(self.tree.focus);
+        let buf = self
+            .buffers
+            .get_mut(&self.focused_buf_id)
+            .expect("Focus buffer didn't found");
+
+        return (view, buf);
+    }
+
+    pub fn focus_ref(&self) -> (&Window, &Buffer) {
+        let view = self.tree.get(self.tree.focus);
+        let buf = &self.buffers[&self.focused_buf_id];
+
+        return (view, buf);
+    }
+
+    pub fn update_scroll(&mut self) {
+        let screen_height = self.screen_height;
+        let screen_width = self.screen_width;
+        let offset = self.config.scroll_offset;
+
+        let (window, _buf) = self.focus();
+        window.update_scroll(screen_height, offset, screen_width, offset);
+    }
+
+    pub fn get_buffers_cloned(&self) -> Vec<Buffer> {
+        self.buffers.values().cloned().collect()
+    }
+
+    pub fn focus_buf(&mut self, buf_id: BufferId) {
+        let id = self.tree.insert(Window::new(buf_id));
+        self.tree.focus = id;
     }
 }
 

--- a/benihime-core/src/graphics.rs
+++ b/benihime-core/src/graphics.rs
@@ -1,7 +1,6 @@
 use std::cmp::{max, min};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CursorKind {
     #[default]
     Block,
@@ -10,7 +9,6 @@ pub enum CursorKind {
     Hollow,
     Hidden,
 }
-
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Margin {

--- a/benihime-core/src/input_handler.rs
+++ b/benihime-core/src/input_handler.rs
@@ -1,7 +1,7 @@
 use benihime_renderer::event::{InputEvent, Key, KeyPress, MouseEvent, ScrollDelta};
 
 use crate::{
-    buffer::Mode,
+    editor::Mode,
     keymap::key_chord::{KeyChord, KeyModifiers},
 };
 

--- a/benihime-core/src/keymap/default_keymap.rs
+++ b/benihime-core/src/keymap/default_keymap.rs
@@ -1,6 +1,6 @@
 use benihime_renderer::event::Key;
 
-use crate::{buffer::Mode, command::CommandArg};
+use crate::{command::CommandArg, editor::Mode};
 
 use super::{
     key_chord::{KeyChord, KeyModifiers},

--- a/benihime-core/src/keymap/default_keymap.rs
+++ b/benihime-core/src/keymap/default_keymap.rs
@@ -504,6 +504,38 @@ pub fn register_default_keymap(km: &mut Keymap) {
         &[Mode::Normal],
         KeySequence::new(vec![
             KeyChord {
+                code: Key::Char('w'),
+                modifiers: KeyModifiers::CTRL,
+            },
+            KeyChord {
+                code: Key::Char('s'),
+                modifiers: KeyModifiers::NONE,
+            },
+        ]),
+        "split-window-horizontal",
+        None,
+    );
+
+    km.bind(
+        &[Mode::Normal],
+        KeySequence::new(vec![
+            KeyChord {
+                code: Key::Char('w'),
+                modifiers: KeyModifiers::CTRL,
+            },
+            KeyChord {
+                code: Key::Char('v'),
+                modifiers: KeyModifiers::NONE,
+            },
+        ]),
+        "split-window-vertical",
+        None,
+    );
+
+    km.bind(
+        &[Mode::Normal],
+        KeySequence::new(vec![
+            KeyChord {
                 code: Key::Char('g'),
                 modifiers: KeyModifiers::NONE,
             },

--- a/benihime-core/src/keymap/mod.rs
+++ b/benihime-core/src/keymap/mod.rs
@@ -3,7 +3,7 @@ pub mod key_chord;
 
 use std::collections::HashMap;
 
-use crate::{editor::Mode, command::CommandArg, keymap::key_chord::KeyChord};
+use crate::{command::CommandArg, editor::Mode, keymap::key_chord::KeyChord};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeySequence {

--- a/benihime-core/src/keymap/mod.rs
+++ b/benihime-core/src/keymap/mod.rs
@@ -3,7 +3,7 @@ pub mod key_chord;
 
 use std::collections::HashMap;
 
-use crate::{buffer::Mode, command::CommandArg, keymap::key_chord::KeyChord};
+use crate::{editor::Mode, command::CommandArg, keymap::key_chord::KeyChord};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeySequence {

--- a/benihime-core/src/main.rs
+++ b/benihime-core/src/main.rs
@@ -2,7 +2,6 @@ use application::Application;
 
 mod application;
 mod buffer;
-mod buffer_manager;
 mod chars;
 mod command;
 mod editor;
@@ -15,15 +14,15 @@ mod movement;
 mod position;
 mod project;
 mod theme;
+mod tree;
 mod ui;
 mod undotree;
+mod window;
 
 fn main() -> anyhow::Result<()> {
     let window_config = benihime_renderer::WindowConfig::new("The Editor", false);
 
     let app = Application::new();
-
-    
 
     benihime_renderer::run(window_config, app)
         .map_err(|e| anyhow::anyhow!("Failed to run renderer: {}", e))

--- a/benihime-core/src/mini_buffer.rs
+++ b/benihime-core/src/mini_buffer.rs
@@ -128,11 +128,12 @@ where
 
     fn run_callback(&mut self, editor: &mut Editor) -> Result<MinibufferCallbackResult> {
         if let Some(item) = self.items.get(self.index).cloned()
-            && let Some(new_items) = (self.callback)(editor, &item)? {
-                self.items = new_items;
-                self.index = 0;
-                return Ok(MinibufferCallbackResult::NewItems);
-            }
+            && let Some(new_items) = (self.callback)(editor, &item)?
+        {
+            self.items = new_items;
+            self.index = 0;
+            return Ok(MinibufferCallbackResult::NewItems);
+        }
         Ok(MinibufferCallbackResult::Executed)
     }
 

--- a/benihime-core/src/movement/movement_commands.rs
+++ b/benihime-core/src/movement/movement_commands.rs
@@ -11,19 +11,19 @@ where
     let state = &mut cx.editor;
     let count = 1; // TODO: later read it from contexts repeat count
 
-    let buf = state.focused_buf_mut();
+    let (window, buf) = state.focus();
 
-    if buf.cursor.row < buf.line_count() {
-        let rope_line: RopeSlice = buf.line(buf.cursor.row);
+    if window.cursor.row < buf.line_count() {
+        let rope_line: RopeSlice = buf.line(window.cursor.row);
 
         let selection = Range {
-            anchor: buf.cursor.col,
-            head: buf.cursor.col,
+            anchor: window.cursor.col,
+            head: window.cursor.col,
         };
 
         let new_range = move_fn(rope_line, selection, count);
 
-        buf.cursor.col = new_range.head;
+        window.cursor.col = new_range.head;
         buf.range = Some(new_range);
     }
 }

--- a/benihime-core/src/project/mod.rs
+++ b/benihime-core/src/project/mod.rs
@@ -1,7 +1,7 @@
 // project.rs
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
-use crate::buffer::BufferId;
+use crate::{buffer::BufferId, tree::Tree, window::Window};
 
 pub mod project_manager;
 
@@ -14,4 +14,6 @@ pub struct Project {
     pub name: String,
     pub root: Option<PathBuf>,
     pub buffers: Vec<BufferId>,
+    pub tree: Tree,
+    pub windows: BTreeMap<BufferId, Window>,
 }

--- a/benihime-core/src/project/project_manager.rs
+++ b/benihime-core/src/project/project_manager.rs
@@ -4,7 +4,6 @@ use anyhow::anyhow;
 
 use crate::{
     buffer::BufferId,
-    buffer_manager::BufferManager,
     project::{Project, ProjectId},
 };
 
@@ -133,25 +132,16 @@ impl ProjectManager {
         self.current_mut().buffers.push(id);
     }
 
-    pub fn close_project(
-        &mut self,
-        id: ProjectId,
-        buffer_manager: &mut BufferManager,
-    ) -> anyhow::Result<Vec<BufferId>> {
+    pub fn close_project(&mut self, id: ProjectId) -> anyhow::Result<Vec<BufferId>> {
         if id == DEFAULT_PROJECT_ID {
             return Err(anyhow!("Cannot close the default project"));
         }
 
         let buffer_ids = self.current().buffers.clone();
 
-        let project = self
-            .projects
+        self.projects
             .remove(&id)
             .ok_or_else(|| anyhow!("Project not found"))?;
-
-        for buf_id in project.buffers {
-            buffer_manager.kill_buffer(buf_id);
-        }
 
         if self.current == id {
             self.current = DEFAULT_PROJECT_ID;

--- a/benihime-core/src/project/project_manager.rs
+++ b/benihime-core/src/project/project_manager.rs
@@ -1,10 +1,15 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
 
 use anyhow::anyhow;
 
 use crate::{
     buffer::BufferId,
+    graphics::Rect,
     project::{Project, ProjectId},
+    tree::Tree,
 };
 
 pub const DEFAULT_PROJECT_ID: ProjectId = ProjectId(0);
@@ -14,10 +19,11 @@ pub struct ProjectManager {
     name_index: HashMap<String, ProjectId>,
     current: ProjectId,
     next_id: u64,
+    area: Rect,
 }
 
 impl ProjectManager {
-    pub fn new() -> Self {
+    pub fn new(area: Rect) -> Self {
         let mut projects = HashMap::new();
         let mut name_index = HashMap::new();
 
@@ -26,6 +32,8 @@ impl ProjectManager {
             name: "empty".to_string(),
             root: None,
             buffers: Vec::new(),
+            tree: Tree::new(area),
+            windows: BTreeMap::new(),
         };
 
         projects.insert(DEFAULT_PROJECT_ID, default_project);
@@ -36,6 +44,7 @@ impl ProjectManager {
             name_index,
             current: DEFAULT_PROJECT_ID,
             next_id: 1,
+            area,
         }
     }
 
@@ -48,6 +57,8 @@ impl ProjectManager {
             name: name.clone(),
             root: Some(root),
             buffers: Vec::new(),
+            tree: Tree::new(self.area),
+            windows: BTreeMap::new(),
         };
 
         self.projects.insert(id, project);
@@ -70,6 +81,13 @@ impl ProjectManager {
         self.projects
             .get_mut(&self.current)
             .expect("current project id must always exist")
+    }
+
+    pub fn resize(&mut self, area: Rect) {
+        self.area = area;
+        for project in self.projects.values_mut() {
+            project.tree.resize(area);
+        }
     }
 
     pub fn current_name(&self) -> String {

--- a/benihime-core/src/tree.rs
+++ b/benihime-core/src/tree.rs
@@ -5,7 +5,7 @@ use crate::{
     window::{Window, WindowId},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Tree {
     root: WindowId,
     pub focus: WindowId,
@@ -14,13 +14,14 @@ pub struct Tree {
     nodes: SlotMap<WindowId, Node>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     parent: WindowId,
     content: Content,
+    area: Rect,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Content {
     Window(Box<Window>),
     Container(Box<Container>),
@@ -31,6 +32,7 @@ impl Node {
         Self {
             parent: WindowId::default(),
             content: Content::Container(Box::new(Container::new(layout))),
+            area: Rect::default(),
         }
     }
 
@@ -38,6 +40,7 @@ impl Node {
         Self {
             parent: WindowId::default(),
             content: Content::Window(Box::new(window)),
+            area: Rect::default(),
         }
     }
 
@@ -63,11 +66,10 @@ pub enum Direction {
     Right,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Container {
     layout: Layout,
     children: Vec<WindowId>,
-    area: Rect,
 }
 
 impl Container {
@@ -75,7 +77,6 @@ impl Container {
         Self {
             layout,
             children: Vec::new(),
-            area: Rect::default(),
         }
     }
 }
@@ -139,12 +140,254 @@ impl Tree {
         self.area
     }
 
-    pub fn insert(&mut self, window: Window) -> WindowId {
-        let node = Node::window(window);
-        let id = self.nodes.insert(node);
-        if let Content::Container(c) = &mut self.nodes[self.root].content {
-            c.children.push(id);
+    pub fn resize(&mut self, area: Rect) -> bool {
+        if self.area != area {
+            self.area = area;
+            self.recalculate();
+            return true;
         }
-        id
+        false
+    }
+
+    pub fn insert(&mut self, window: Window) -> WindowId {
+        let focus = self.focus;
+        let parent = self.nodes[focus].parent;
+        let mut node = Node::window(window);
+        node.parent = parent;
+        let node = self.nodes.insert(node);
+        self.get_mut(node).id = node;
+
+        let container = match &mut self.nodes[parent] {
+            Node {
+                content: Content::Container(container),
+                ..
+            } => container,
+            _ => unreachable!(),
+        };
+
+        let pos = if container.children.is_empty() {
+            0
+        } else {
+            let pos = container
+                .children
+                .iter()
+                .position(|&child| child == focus)
+                .unwrap();
+            pos + 1
+        };
+
+        container.children.insert(pos, node);
+        self.focus = node;
+
+        self.recalculate();
+
+        node
+    }
+
+    pub fn set_single_window(&mut self, window: Window) -> WindowId {
+        let area = self.area;
+        let mut nodes = SlotMap::with_key();
+
+        let root = nodes.insert(Node::container(Layout::Vertical));
+        nodes[root].parent = root;
+
+        let mut node = Node::window(window);
+        node.parent = root;
+        node.area = area;
+        let window_id = nodes.insert(node);
+
+        match &mut nodes[root].content {
+            Content::Container(container) => container.children.push(window_id),
+            Content::Window(_) => unreachable!(),
+        }
+
+        match &mut nodes[window_id].content {
+            Content::Window(window) => window.id = window_id,
+            Content::Container(_) => unreachable!(),
+        }
+
+        self.root = root;
+        self.focus = window_id;
+        self.nodes = nodes;
+        self.recalculate();
+
+        window_id
+    }
+
+    pub fn split(&mut self, window: Window, layout: Layout) -> WindowId {
+        let focus = self.focus;
+        let parent = self.nodes[focus].parent;
+
+        let node = Node::window(window);
+        let node = self.nodes.insert(node);
+        self.get_mut(node).id = node;
+
+        let container = match &mut self.nodes[parent] {
+            Node {
+                content: Content::Container(container),
+                ..
+            } => container,
+            _ => unreachable!(),
+        };
+        if container.layout == layout {
+            let pos = if container.children.is_empty() {
+                0
+            } else {
+                let pos = container
+                    .children
+                    .iter()
+                    .position(|&child| child == focus)
+                    .unwrap();
+                pos + 1
+            };
+            container.children.insert(pos, node);
+            self.nodes[node].parent = parent;
+        } else {
+            let mut split = Node::container(layout);
+            split.parent = parent;
+            let split = self.nodes.insert(split);
+
+            let container = match &mut self.nodes[split] {
+                Node {
+                    content: Content::Container(container),
+                    ..
+                } => container,
+                _ => unreachable!(),
+            };
+            container.children.push(focus);
+            container.children.push(node);
+            self.nodes[focus].parent = split;
+            self.nodes[node].parent = split;
+
+            let container = match &mut self.nodes[parent] {
+                Node {
+                    content: Content::Container(container),
+                    ..
+                } => container,
+                _ => unreachable!(),
+            };
+
+            let pos = container
+                .children
+                .iter()
+                .position(|&child| child == focus)
+                .unwrap();
+
+            container.children[pos] = split;
+        }
+
+        self.focus = node;
+
+        self.recalculate();
+
+        node
+    }
+
+    pub fn windows(&self) -> impl Iterator<Item = (&Window, Rect, bool)> {
+        let focus = self.focus;
+        self.nodes.iter().filter_map(move |(key, node)| match node {
+            Node {
+                content: Content::Window(view),
+                ..
+            } => Some((view.as_ref(), node.area, focus == key)),
+            _ => None,
+        })
+    }
+
+    pub fn recalculate(&mut self) {
+        let root = self.root;
+        let area = self.area;
+
+        self.recalculate_node(root, area);
+    }
+
+    fn recalculate_node(&mut self, node_id: WindowId, area: Rect) {
+        let node = match self.nodes.get_mut(node_id) {
+            Some(node) => node,
+            None => return,
+        };
+
+        node.area = area;
+
+        let children_to_visit = {
+            let node = match self.nodes.get_mut(node_id) {
+                Some(node) => node,
+                None => return,
+            };
+
+            node.area = area;
+
+            match &mut node.content {
+                Content::Window(_window) => None,
+
+                Content::Container(container) => {
+                    Some((container.layout, container.children.clone()))
+                }
+            }
+        };
+
+        let Some((direction, children)) = children_to_visit else {
+            return;
+        };
+
+        if children.is_empty() {
+            return;
+        }
+
+        let count = children.len() as u16;
+
+        match direction {
+            Layout::Vertical => {
+                let base_width = area.width / count;
+                let remainder = area.width % count;
+
+                let mut current_x = area.x;
+
+                for (i, child_id) in children.iter().enumerate() {
+                    let extra = if i == children.len() - 1 {
+                        remainder
+                    } else {
+                        0
+                    };
+
+                    let child_rect = Rect {
+                        x: current_x,
+                        y: area.y,
+                        width: base_width + extra,
+                        height: area.height,
+                    };
+
+                    current_x += child_rect.width;
+
+                    self.recalculate_node(*child_id, child_rect);
+                }
+            }
+
+            Layout::Horizontal => {
+                let base_height = area.height / count;
+                let remainder = area.height % count;
+
+                let mut current_y = area.y;
+
+                for (i, child_id) in children.iter().enumerate() {
+                    let extra = if i == children.len() - 1 {
+                        remainder
+                    } else {
+                        0
+                    };
+
+                    let child_rect = Rect {
+                        x: area.x,
+                        y: current_y,
+                        width: area.width,
+                        height: base_height + extra,
+                    };
+
+                    current_y += child_rect.height;
+
+                    self.recalculate_node(*child_id, child_rect);
+                }
+            }
+        }
     }
 }

--- a/benihime-core/src/tree.rs
+++ b/benihime-core/src/tree.rs
@@ -1,0 +1,150 @@
+use slotmap::SlotMap;
+
+use crate::{
+    graphics::Rect,
+    window::{Window, WindowId},
+};
+
+#[derive(Debug)]
+pub struct Tree {
+    root: WindowId,
+    pub focus: WindowId,
+    area: Rect,
+
+    nodes: SlotMap<WindowId, Node>,
+}
+
+#[derive(Debug)]
+pub struct Node {
+    parent: WindowId,
+    content: Content,
+}
+
+#[derive(Debug)]
+pub enum Content {
+    Window(Box<Window>),
+    Container(Box<Container>),
+}
+
+impl Node {
+    pub fn container(layout: Layout) -> Self {
+        Self {
+            parent: WindowId::default(),
+            content: Content::Container(Box::new(Container::new(layout))),
+        }
+    }
+
+    pub fn window(window: Window) -> Self {
+        Self {
+            parent: WindowId::default(),
+            content: Content::Window(Box::new(window)),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match &self.content {
+            Content::Container(c) => c.children.is_empty(),
+            Content::Window(_container) => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Layout {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+#[derive(Debug)]
+pub struct Container {
+    layout: Layout,
+    children: Vec<WindowId>,
+    area: Rect,
+}
+
+impl Container {
+    pub fn new(layout: Layout) -> Self {
+        Self {
+            layout,
+            children: Vec::new(),
+            area: Rect::default(),
+        }
+    }
+}
+
+impl Default for Container {
+    fn default() -> Self {
+        Self::new(Layout::Vertical)
+    }
+}
+
+impl Tree {
+    pub fn new(area: Rect) -> Self {
+        let root = Node::container(Layout::Vertical);
+
+        let mut nodes = SlotMap::with_key();
+        let root = nodes.insert(root);
+
+        nodes[root].parent = root;
+
+        Self {
+            root,
+            focus: root,
+            area,
+            nodes,
+        }
+    }
+
+    pub fn get(&self, index: WindowId) -> &Window {
+        self.try_get(index).unwrap()
+    }
+
+    pub fn try_get(&self, index: WindowId) -> Option<&Window> {
+        match self.nodes.get(index) {
+            Some(Node {
+                content: Content::Window(window),
+                ..
+            }) => Some(window),
+            _ => None,
+        }
+    }
+
+    pub fn get_mut(&mut self, index: WindowId) -> &mut Window {
+        match &mut self.nodes[index] {
+            Node {
+                content: Content::Window(view),
+                ..
+            } => view,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        *&self.nodes[self.root].is_empty()
+    }
+
+    pub fn contains(&self, index: WindowId) -> bool {
+        self.nodes.contains_key(index)
+    }
+
+    pub fn area(&self) -> Rect {
+        self.area
+    }
+
+    pub fn insert(&mut self, window: Window) -> WindowId {
+        let node = Node::window(window);
+        let id = self.nodes.insert(node);
+        if let Content::Container(c) = &mut self.nodes[self.root].content {
+            c.children.push(id);
+        }
+        id
+    }
+}

--- a/benihime-core/src/ui/components/cursor.rs
+++ b/benihime-core/src/ui/components/cursor.rs
@@ -2,7 +2,7 @@ use benihime_renderer::Renderer;
 
 use crate::{
     application::Application,
-    buffer::Mode,
+    editor::Mode,
     graphics::{CursorKind, Rect},
     position::Position,
     ui::composer::{Component, Context},
@@ -25,10 +25,10 @@ impl Default for CursorComponent {
 impl Component for CursorComponent {
     fn render(&mut self, area: Rect, surface: &mut Renderer, ctx: &mut Context) {
         let editor = &ctx.editor;
-        let buffer = editor.focused_buf();
+        let (window, _buf) = editor.focus_ref();
 
-        let cursor_row = buffer.cursor.row.saturating_sub(buffer.scroll_offset);
-        let cursor_col = buffer.cursor.col.saturating_sub(buffer.scroll_left);
+        let cursor_row = window.cursor.row.saturating_sub(window.scroll_offset);
+        let cursor_col = window.cursor.col.saturating_sub(window.scroll_left);
 
         let cell_width = surface.cell_width();
         let cell_height = surface.cell_height();
@@ -58,7 +58,7 @@ impl Component for CursorComponent {
         let y = y_offset as f32 + (cursor_row as f32 * cell_height);
         let x = editor_start_x as f32 + (cursor_col as f32 * cell_width);
 
-        let cursor_kind = match buffer.mode {
+        let cursor_kind = match window.mode {
             Mode::Insert => CursorKind::Bar,
             _ => CursorKind::Block,
         };
@@ -88,12 +88,12 @@ impl Component for CursorComponent {
 
     fn cursor(&self, _area: Rect, app: &Application) -> (Option<Position>, CursorKind) {
         let editor = &app.editor;
-        let buffer = editor.focused_buf();
+        let (window, _buf) = editor.focus_ref();
 
-        let cursor_row = buffer.cursor.row.saturating_sub(buffer.scroll_offset);
-        let cursor_col = buffer.cursor.col.saturating_sub(buffer.scroll_left);
+        let cursor_row = window.cursor.row.saturating_sub(window.scroll_offset);
+        let cursor_col = window.cursor.col.saturating_sub(window.scroll_left);
 
-        let cursor_kind = match buffer.mode {
+        let cursor_kind = match window.mode {
             Mode::Insert => CursorKind::Bar,
             _ => CursorKind::Block,
         };

--- a/benihime-core/src/ui/editor_view.rs
+++ b/benihime-core/src/ui/editor_view.rs
@@ -1,8 +1,11 @@
 use benihime_renderer::{Renderer, color::Color};
 
 use crate::{
+    buffer::Buffer,
+    editor::Editor,
     graphics::Rect,
     ui::composer::{Component, Context},
+    window::Window,
 };
 
 pub struct EditorView {
@@ -13,18 +16,15 @@ impl EditorView {
     pub fn new() -> Self {
         Self { scroll_offset: 0 }
     }
-}
 
-impl Default for EditorView {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Component for EditorView {
-    fn render(&mut self, area: Rect, surface: &mut Renderer, ctx: &mut Context) {
-        let editor = &ctx.editor;
-        let (window, buffer) = editor.focus_ref();
+    pub fn render_view(
+        &self,
+        area: Rect,
+        surface: &mut Renderer,
+        editor: &Editor,
+        window: &Window,
+        buffer: &Buffer,
+    ) {
         let line_count = buffer.line_count();
 
         let cell_width = surface.cell_width();
@@ -160,6 +160,23 @@ impl Component for EditorView {
                     surface.draw_text(section);
                 }
             }
+        }
+    }
+}
+
+impl Default for EditorView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Component for EditorView {
+    fn render(&mut self, _area: Rect, surface: &mut Renderer, ctx: &mut Context) {
+        let editor = &ctx.editor;
+
+        for (window, node_area, _is_focus) in editor.tree().windows() {
+            let buffer = editor.buf(window.buffer_id).unwrap();
+            self.render_view(node_area, surface, editor, window, buffer);
         }
     }
 

--- a/benihime-core/src/ui/editor_view.rs
+++ b/benihime-core/src/ui/editor_view.rs
@@ -1,4 +1,4 @@
-use benihime_renderer::{color::Color, Renderer};
+use benihime_renderer::{Renderer, color::Color};
 
 use crate::{
     graphics::Rect,
@@ -24,7 +24,7 @@ impl Default for EditorView {
 impl Component for EditorView {
     fn render(&mut self, area: Rect, surface: &mut Renderer, ctx: &mut Context) {
         let editor = &ctx.editor;
-        let buffer = editor.focused_buf();
+        let (window, buffer) = editor.focus_ref();
         let line_count = buffer.line_count();
 
         let cell_width = surface.cell_width();
@@ -68,11 +68,11 @@ impl Component for EditorView {
 
         let visible_lines = (editor_area_height as f32 / cell_height).floor() as usize;
 
-        let start_line = buffer.scroll_offset;
+        let start_line = window.scroll_offset;
         let end_line = (start_line + visible_lines).min(line_count);
-        let cursor_row = buffer.cursor.row;
+        let cursor_row = window.cursor.row;
 
-        let scroll_left = buffer.scroll_left;
+        let scroll_left = window.scroll_left;
         let visible_cols = (area.width as f32 / cell_width).floor() as usize;
 
         for (row, line_idx) in (start_line..end_line).enumerate() {

--- a/benihime-core/src/ui/mod.rs
+++ b/benihime-core/src/ui/mod.rs
@@ -1,4 +1,4 @@
-pub mod composer;
 pub mod components;
+pub mod composer;
 pub mod editor_view;
 pub mod job;

--- a/benihime-core/src/window.rs
+++ b/benihime-core/src/window.rs
@@ -1,0 +1,103 @@
+use crate::{
+    buffer::{BufferId, Position},
+    editor::Mode,
+    graphics::Rect,
+};
+
+slotmap::new_key_type! {
+    pub struct WindowId;
+}
+
+#[derive(Debug)]
+pub struct Window {
+    pub id: WindowId,
+    pub buffer_id: BufferId,
+    pub cursor: Position,
+    pub scroll_offset: usize,
+    pub scroll_left: usize,
+    pub rect: Rect,
+    pub mode: Mode,
+}
+
+impl Window {
+    pub fn new(buffer_id: BufferId) -> Self {
+        Self {
+            id: WindowId::default(),
+            buffer_id,
+            cursor: Position::start(),
+            scroll_offset: 0,
+            scroll_left: 0,
+            rect: Rect::default(),
+            mode: Mode::Normal,
+        }
+    }
+
+    pub fn scroll_down(
+        &mut self,
+        lines: usize,
+        screen_height: usize,
+        scrolloff: usize,
+        lines_len: usize,
+    ) {
+        let max_row = lines_len.saturating_sub(1);
+
+        let new_row = (self.cursor.row + lines).min(max_row);
+        self.cursor.row = new_row;
+
+        if new_row >= self.scroll_offset.saturating_add(screen_height).saturating_sub(scrolloff) {
+            self.scroll_offset = new_row.saturating_add(scrolloff + 1).saturating_sub(screen_height);
+        }
+        self.scroll_offset = self
+            .scroll_offset
+            .min(max_row.saturating_add(1).saturating_sub(screen_height));
+    }
+
+    pub fn scroll_up(&mut self, lines: usize, scrolloff: usize) {
+        let new_row = self.cursor.row.saturating_sub(lines);
+        self.cursor.row = new_row;
+
+        if new_row < self.scroll_offset + scrolloff {
+            self.scroll_offset = new_row.saturating_sub(scrolloff);
+        }
+    }
+
+    pub fn center_cursor(&mut self, screen_height: usize, lines_len: usize) {
+        let cursor_row = self.cursor.row.min(lines_len.saturating_sub(1));
+
+        let half_screen = screen_height / 2;
+        if cursor_row >= half_screen {
+            self.scroll_offset = cursor_row.saturating_sub(half_screen);
+        } else {
+            self.scroll_offset = 0;
+        }
+
+        if self.scroll_offset + screen_height > lines_len {
+            self.scroll_offset = lines_len.saturating_sub(screen_height);
+        }
+    }
+
+    pub fn update_scroll(
+        &mut self,
+        screen_height: usize,
+        vertical_scrolloff: usize,
+        screen_width: usize,
+        horizontal_scrolloff: usize,
+    ) {
+        let row = self.cursor.row;
+        let col = self.cursor.col;
+
+        if row < self.scroll_offset + vertical_scrolloff {
+            self.scroll_offset = row.saturating_sub(vertical_scrolloff);
+        }
+
+        if row >= self.scroll_offset + screen_height - vertical_scrolloff {
+            self.scroll_offset = row + vertical_scrolloff + 1 - screen_height;
+        }
+
+        if col < self.scroll_left + horizontal_scrolloff {
+            self.scroll_left = col.saturating_sub(horizontal_scrolloff);
+        } else if col >= self.scroll_left + screen_width - horizontal_scrolloff {
+            self.scroll_left = col.saturating_sub(screen_width - horizontal_scrolloff);
+        }
+    }
+}

--- a/benihime-core/src/window.rs
+++ b/benihime-core/src/window.rs
@@ -1,21 +1,19 @@
 use crate::{
     buffer::{BufferId, Position},
     editor::Mode,
-    graphics::Rect,
 };
 
 slotmap::new_key_type! {
     pub struct WindowId;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Window {
     pub id: WindowId,
     pub buffer_id: BufferId,
     pub cursor: Position,
     pub scroll_offset: usize,
     pub scroll_left: usize,
-    pub rect: Rect,
     pub mode: Mode,
 }
 
@@ -27,7 +25,6 @@ impl Window {
             cursor: Position::start(),
             scroll_offset: 0,
             scroll_left: 0,
-            rect: Rect::default(),
             mode: Mode::Normal,
         }
     }
@@ -44,8 +41,15 @@ impl Window {
         let new_row = (self.cursor.row + lines).min(max_row);
         self.cursor.row = new_row;
 
-        if new_row >= self.scroll_offset.saturating_add(screen_height).saturating_sub(scrolloff) {
-            self.scroll_offset = new_row.saturating_add(scrolloff + 1).saturating_sub(screen_height);
+        if new_row
+            >= self
+                .scroll_offset
+                .saturating_add(screen_height)
+                .saturating_sub(scrolloff)
+        {
+            self.scroll_offset = new_row
+                .saturating_add(scrolloff + 1)
+                .saturating_sub(screen_height);
         }
         self.scroll_offset = self
             .scroll_offset

--- a/benihime-renderer/src/renderer.rs
+++ b/benihime-renderer/src/renderer.rs
@@ -694,11 +694,11 @@ impl Renderer {
         buffer.shape_until_scroll(&mut self.font_system, false);
 
         let mut measured_glyph_width = self.font_size * 0.55;
-        
+
         if let Some(run) = buffer.layout_runs().next() {
             self.cell_height = run.line_height.max(self.font_size);
             self.line_top_offset = run.line_top;
-            
+
             if run.glyphs.len() >= 2 {
                 let advance = run.glyphs[1].x - run.glyphs[0].x;
                 if advance > 0.0 {
@@ -709,10 +709,15 @@ impl Renderer {
             self.cell_height = self.font_size * LINE_HEIGHT_FACTOR;
             self.line_top_offset = 0.0;
         }
-        
+
         self.cell_width = measured_glyph_width;
-        log::info!("Font metrics: font_size={}, cell_width={}, cell_height={}, ratio={}", 
-            self.font_size, self.cell_width, self.cell_height, self.cell_width / self.font_size);
+        log::info!(
+            "Font metrics: font_size={}, cell_width={}, cell_height={}, ratio={}",
+            self.font_size,
+            self.cell_width,
+            self.cell_height,
+            self.cell_width / self.font_size
+        );
     }
 
     pub fn update_viewport(&mut self, width: u32, height: u32) -> bool {


### PR DESCRIPTION
This PR refactors the editor architecture around `Window`-based view management.

### Changes

* Added `Window` and `Tree` structures for view management
* Integrated `Window` into `Editor` and removed `BufferManager`
* Updated commands, UI, and imports to use `Window`
* Added per-project window state persistence
* Added window splitting support

These changes improve view organization and provide the foundation for multi-window workflows.